### PR TITLE
Prioritize $SHELL environment variable

### DIFF
--- a/shell_windows.go
+++ b/shell_windows.go
@@ -10,8 +10,13 @@ const defaultShell = "powershell.exe"
 
 // CurrentUserShell returns the current user's shell.
 func CurrentUserShell() (string, bool) {
+	// If the SHELL environment variable is set, use it.
+	if shell, ok := os.LookupEnv("SHELL"); ok {
+		return shell, true
+	}
+	
 	// If the ComSpec environment variable is set, use it.
-	if comSpec := os.Getenv("ComSpec"); comSpec != "" {
+	if comSpec, ok := os.LookupEnv("ComSpec"); ok {
 		return comSpec, true
 	}
 


### PR DESCRIPTION
Hiya @twpayne. Love chezmoi; used it for some time on macOS. Recently been trying to use it on Windows specifically with Cygwin. How do you feel about the following change to support *nix like behavior if we're in Cygwin/are using an *nix like environment?

Also updated the exiting comSpec check to use the LookupEnv style you're using in shell_darwin.go, shell_posix.go, etc. Let me know if you'd like me to omit this piece.

Cheers,
Cameron