### PR TITLE
Properly support Solaris-based OSs

### DIFF
--- a/shellcgo.go
+++ b/shellcgo.go
@@ -1,7 +1,9 @@
-// +build cgo,aix cgo,android cgo,darwin cgo,dragonfly cgo,freebsd cgo,illumnos cgo,linux cgo,netbsd cgo,openbsd cgo,solaris
+// +build cgo,aix cgo,android cgo,darwin cgo,dragonfly cgo,freebsd cgo,illumos cgo,linux cgo,netbsd cgo,openbsd cgo,solaris
 
 package shell
 
+// #cgo solaris CFLAGS: -D_POSIX_PTHREAD_SEMANTICS=1
+// #cgo illumos CFLAGS: -D_POSIX_PTHREAD_SEMANTICS=1
 // #include <errno.h>
 // #include <pwd.h>
 // #include <stdlib.h>


### PR DESCRIPTION
`go-shell` fails to build due to Solaris not being POSIX compatible:

```
# github.com/twpayne/go-shell                                                                                    
./shellcgo.go:30:21: too many arguments in call to _Cfunc_getpwnam_r
        have (*_Ctype_char, *_Ctype_struct_passwd, *_Ctype_char, _Ctype_ulong, **_Ctype_struct_passwd)
        want (*_Ctype_char, *_Ctype_struct_passwd, *_Ctype_char, _Ctype_int)
./shellcgo.go:34:3: invalid case 0 in switch on rc (mismatched types int and *_Ctype_struct_passwd)
./shellcgo.go:36:3: invalid case _Ciconst_ERANGE in switch on rc (mismatched types int and *_Ctype_struct_passwd)
```

`getpwnam_r()` can be used in a POSIX-conforming way on Solaris-based OSs though, by using `–D_POSIX_PTHREAD_SEMANTICS` as specified [in the documentation](https://docs.oracle.com/cd/E36784_01/html/E36874/getpwnam-r-3c.html).